### PR TITLE
publicize SFE_ARTEMIS_MODULE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7433,7 +7433,6 @@
         "inherits": ["AMA3B1KK"]
     },
     "SFE_ARTEMIS_MODULE": {
-        "public": false,
         "inherits": ["AMA3B1KK"]
     },
     "SFE_ARTEMIS_NANO": {


### PR DESCRIPTION
once upon a time this was meant to be private to inherit to other targets

since the bare Artemis module is a valid variant in Arduino and it has its own BSP it should have the same status as other targets