### PR TITLE
Update PinNames.h to include user button on the Thing Plus board

### DIFF
--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_SFE_ARTEMIS_THING_PLUS/PinNames.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_SFE_ARTEMIS_THING_PLUS/PinNames.h
@@ -70,6 +70,9 @@ typedef enum
     A5 = D24,
     A6 = D3,
 
+    //BUTTONs
+    SW1 = AM_BSP_GPIO_BUTTON0,
+    
     // LEDs
     LED_BLUE = AM_BSP_GPIO_LED_BLUE,
 


### PR DESCRIPTION
In Ambiq SDK (TARGET_SFE_ARTEMIS_THING_PLUS/bsp/am_bsp_pins.h) the pin for the on-board user button is already defined.
However in TARGET_SFE_ARTEMIS_THING_PLUS/PinNames.h there are no pin definitions for the on-board button, as a consequence in mbed-os we can not reference it by the name.

Following mbed-os pin naming conventions buttons have a pin name like SW1 (not like BUTTON1).
This PR adds a name reference to TARGET_SFE_ARTEMIS_THING_PLUS/PinNames.h so that we can use SW1 in mbed-os as an alias for the pin definition defined in the corresponding bsp.

I think only the Artemis Thing Plus has an on-board user button, so other boards might not be affected.

<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
