### PR TITLE
Ambiq apollo3 serial fix

### DIFF
--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -31,7 +31,6 @@ SOFTWARE.
 int stdio_uart_inited = 0;
 serial_t stdio_uart;
 bool value = false;
-bool serialinitialized = false;
 
 // interrupt variables
 static uart_irq_handler irq_handler;
@@ -147,18 +146,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     MBED_ASSERT(am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false) == AM_HAL_STATUS_SUCCESS);
     MBED_ASSERT(am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg)) == AM_HAL_STATUS_SUCCESS);
 
-    // am_hal_uart_initialize(uart, &(obj->serial.uart_control->handle));
-    // am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false);
-    // am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg));
-
-    // set default baud rate and format
-    // serial_baud(obj, 9600);
+    // set default format
     serial_format(obj, 8, ParityNone, 1);
-  }
-  else
-  {
-    //printf("UART already set-up\r\n");
-    //while(1);
   }
   
 }
@@ -266,20 +255,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         break;
     }
   }
-    
-  //MBED_ASSERT(am_hal_uart_interrupt_enable(obj->serial.uart_control->handle, (AM_HAL_UART_INT_RX | AM_HAL_UART_INT_TX | AM_HAL_UART_INT_TXCMP)) == AM_HAL_STATUS_SUCCESS);
-  //uint32_t retVal = (obj->serial.uart_control->handle, (AM_HAL_UART_INT_RX | AM_HAL_UART_INT_TX | AM_HAL_UART_INT_TXCMP) == AM_HAL_STATUS_SUCCESS);
-  // switch (obj->serial.uart_control->inst)
-  // {
-  //   case 0:
-  //     NVIC_SetVector((IRQn_Type)UART0_IRQn, (uint32_t)am_uart_isr);
-  //     break;
-  //   case 1:
-  //     NVIC_SetVector((IRQn_Type)UART1_IRQn, (uint32_t)am_uart1_isr);
-  //     break;
-  // }
-
-  //NVIC_EnableIRQ((IRQn_Type)(UART0_IRQn + obj->serial.uart_control->inst));
+  
 }
 
 int serial_getc(serial_t *obj)
@@ -381,72 +357,6 @@ const PinMap *serial_cts_pinmap(void) {
 const PinMap *serial_rts_pinmap(void) {
   return PinMap_UART_RTS;
 }
-#endif
-
-#if DEVICE_SERIAL_ASYNCH
-
-int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx_width, uint32_t handler, uint32_t event, DMAUsage hint)
-{
-  MBED_ASSERT(obj->serial.uart_control != NULL);
-  uint32_t bytes_written = 0;
-
-  am_hal_uart_transfer_t am_hal_uart_xfer_write = {
-    .ui32Direction = AM_HAL_UART_WRITE,
-    .pui8Data = (uint8_t *)obj->tx_buff.buffer,
-    .ui32NumBytes = tx_length, // todo: consider maybe this? (uint32_t)obj->tx_buff.length,
-    .ui32TimeoutMs = 0,
-    .pui32BytesTransferred = &bytes_written,
-  };
-
-  am_hal_uart_transfer(obj->serial.uart_control->handle, &am_hal_uart_xfer_write);
-
-  return (int)bytes_written;
-}
-
-void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_width, uint32_t handler, uint32_t event, uint8_t char_match, DMAUsage hint)
-{
-  // todo: revisit
-  MBED_ASSERT(obj->serial.uart_control != NULL);
-  uint32_t bytes_read = 0;
-
-  am_hal_uart_transfer_t am_hal_uart_xfer_read = {
-    .ui32Direction = AM_HAL_UART_READ,
-    .pui8Data = (uint8_t *)obj->rx_buff.buffer,
-    .ui32NumBytes = rx_length, // todo: consider this (uint32_t)obj->rx_buff.length,
-    .ui32TimeoutMs = 0,
-    .pui32BytesTransferred = &bytes_read,
-  };
-
-  am_hal_uart_transfer(obj->serial.uart_control->handle, &am_hal_uart_xfer_read);
-}
-
-uint8_t serial_tx_active(serial_t *obj) {
-  // todo:
-  MBED_ASSERT(0);
-}
-
-uint8_t serial_rx_active(serial_t *obj) {
-  // todo:
-  MBED_ASSERT(0);
-}
-
-int serial_irq_handler_asynch(serial_t *obj) {
-  // todo:
-  MBED_ASSERT(0);
-}
-
-void serial_tx_abort_asynch(serial_t *obj) {
-  // todo:
-  MBED_ASSERT(0);
-}
-
-void serial_rx_abort_asynch(serial_t *obj) {
-  // todo:
-  MBED_ASSERT(0);
-}
-
-/**@}*/
-
 #endif
 
 static inline void uart_irq(uint32_t instance)

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -118,7 +118,6 @@ void uart_configure_pin_function(PinName pin, UARTName uart, const PinMap *map);
  */
 
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
-  //TODO: we should be able to call this multiple times
   // determine the UART to use
   UARTName uart_tx = (UARTName)pinmap_peripheral(tx, serial_tx_pinmap());
   UARTName uart_rx = (UARTName)pinmap_peripheral(rx, serial_rx_pinmap());
@@ -126,7 +125,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
   MBED_ASSERT((int)uart != NC);
   obj->serial.uart_control = &ap3_uart_control[uart];
   obj->serial.uart_control->inst = uart;
-    // config uart pins
+
+  // config uart pins
   pinmap_config(tx, serial_tx_pinmap());
   pinmap_config(rx, serial_rx_pinmap());
 
@@ -149,12 +149,9 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // set default format
     serial_format(obj, 8, ParityNone, 1);
   }
-  
 }
 
-void serial_free(serial_t *obj)
-{
-  //serialinitialized = false;
+void serial_free(serial_t *obj) {
   // nothing to do unless resources are allocated for members of the serial_s serial member of obj
   // assuming mbed handles obj and its members
 }
@@ -164,8 +161,7 @@ void serial_baud(serial_t *obj, int baudrate) {
   MBED_ASSERT(am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg)) == AM_HAL_STATUS_SUCCESS);
 }
 
-void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
-{
+void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
   uint32_t am_hal_data_bits = 0;
   switch (data_bits) {
     case 5:
@@ -221,14 +217,12 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
   MBED_ASSERT(am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg)) == AM_HAL_STATUS_SUCCESS);
 }
 
-void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
-{
+void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id) {
   irq_handler = handler;
   obj->serial.uart_control->serial_irq_id = id;
 }
 
-void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
-{
+void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable) {
   MBED_ASSERT(obj->serial.uart_control->handle != NULL);
   if (enable) {
     switch (irq) {
@@ -255,11 +249,9 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         break;
     }
   }
-  
 }
 
-int serial_getc(serial_t *obj)
-{
+int serial_getc(serial_t *obj) {
   MBED_ASSERT(obj->serial.uart_control != NULL);
 
   uint8_t rx_c = 0x00;
@@ -279,8 +271,7 @@ int serial_getc(serial_t *obj)
   return (int)rx_c;
 }
 
-void serial_putc(serial_t *obj, int c)
-{
+void serial_putc(serial_t *obj, int c) {
   MBED_ASSERT(obj->serial.uart_control != NULL);
 
   volatile uint32_t bytes_sent = 0;

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -130,9 +130,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
   pinmap_config(tx, serial_tx_pinmap());
   pinmap_config(rx, serial_rx_pinmap());
 
-  if(!obj->serial.uart_control->handle)
-  {
-    //printf("setting up UART first time?\r\n");
+  if(!obj->serial.uart_control->handle) {
+    // if handle uninitialized this is first time set up
     // ensure that HAL queueing is disabled (we want to use the FIFOs directly)
     obj->serial.uart_control->cfg.pui8RxBuffer = NULL;
     obj->serial.uart_control->cfg.pui8TxBuffer = NULL;

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -143,7 +143,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // start UART instance
     MBED_ASSERT(am_hal_uart_initialize(uart, &(obj->serial.uart_control->handle)) == AM_HAL_STATUS_SUCCESS);
     MBED_ASSERT(am_hal_uart_power_control(obj->serial.uart_control->handle, AM_HAL_SYSCTRL_WAKE, false) == AM_HAL_STATUS_SUCCESS);
-    MBED_ASSERT(am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg)) == AM_HAL_STATUS_SUCCESS);
+    MBED_ASSERT(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false) == AM_HAL_STATUS_SUCCESS);
 
     // set default format
     serial_format(obj, 8, ParityNone, 1);
@@ -157,7 +157,7 @@ void serial_free(serial_t *obj) {
 
 void serial_baud(serial_t *obj, int baudrate) {
   obj->serial.uart_control->cfg.ui32BaudRate = (uint32_t)baudrate;
-  MBED_ASSERT(am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg)) == AM_HAL_STATUS_SUCCESS);
+  MBED_ASSERT(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false) == AM_HAL_STATUS_SUCCESS);
 }
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
@@ -213,7 +213,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
   obj->serial.uart_control->cfg.ui32DataBits = (uint32_t)am_hal_data_bits;
   obj->serial.uart_control->cfg.ui32Parity = (uint32_t)am_hal_parity;
   obj->serial.uart_control->cfg.ui32StopBits = (uint32_t)am_hal_stop_bits;
-  MBED_ASSERT(am_hal_uart_configure(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg)) == AM_HAL_STATUS_SUCCESS);
+  MBED_ASSERT(am_hal_uart_configure_fifo(obj->serial.uart_control->handle, &(obj->serial.uart_control->cfg), false) == AM_HAL_STATUS_SUCCESS);
 }
 
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id) {

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/device/serial_api.c
@@ -384,7 +384,6 @@ static inline void uart_irq(uint32_t instance)
 }
 
 extern void am_uart_isr(void) {
-  am_hal_gpio_output_set(16); // todo: this should not be here!
   uart_irq(UART_0);
 }
 

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/mcu/apollo3/hal/am_hal_uart.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/mcu/apollo3/hal/am_hal_uart.c
@@ -420,7 +420,7 @@ am_hal_uart_configure(void *pHandle, const am_hal_uart_config_t *psConfig)
     UARTn(ui32Module)->LCRH = (psConfig->ui32DataBits   |
                                psConfig->ui32Parity     |
                                psConfig->ui32StopBits   |
-                               AM_HAL_UART_FIFO_ENABLE);
+                               AM_HAL_UART_FIFO_DISABLE);
 
     //
     // Enable the UART, RX, and TX.
@@ -436,11 +436,11 @@ am_hal_uart_configure(void *pHandle, const am_hal_uart_config_t *psConfig)
     //
     // Set up any buffers that might exist.
     //
-    buffer_configure(pHandle,
-                     psConfig->pui8TxBuffer,
-                     psConfig->ui32TxBufferSize,
-                     psConfig->pui8RxBuffer,
-                     psConfig->ui32RxBufferSize);
+    // buffer_configure(pHandle,
+    //                  psConfig->pui8TxBuffer,
+    //                  psConfig->ui32TxBufferSize,
+    //                  psConfig->pui8RxBuffer,
+    //                  psConfig->ui32RxBufferSize);
 
     return AM_HAL_STATUS_SUCCESS;
 } // am_hal_uart_configure()

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/mcu/apollo3/hal/am_hal_uart.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/mcu/apollo3/hal/am_hal_uart.c
@@ -420,7 +420,7 @@ am_hal_uart_configure(void *pHandle, const am_hal_uart_config_t *psConfig)
     UARTn(ui32Module)->LCRH = (psConfig->ui32DataBits   |
                                psConfig->ui32Parity     |
                                psConfig->ui32StopBits   |
-                               AM_HAL_UART_FIFO_DISABLE);
+                               AM_HAL_UART_FIFO_ENABLE);
 
     //
     // Enable the UART, RX, and TX.
@@ -436,14 +436,104 @@ am_hal_uart_configure(void *pHandle, const am_hal_uart_config_t *psConfig)
     //
     // Set up any buffers that might exist.
     //
-    // buffer_configure(pHandle,
-    //                  psConfig->pui8TxBuffer,
-    //                  psConfig->ui32TxBufferSize,
-    //                  psConfig->pui8RxBuffer,
-    //                  psConfig->ui32RxBufferSize);
+    buffer_configure(pHandle,
+                     psConfig->pui8TxBuffer,
+                     psConfig->ui32TxBufferSize,
+                     psConfig->pui8RxBuffer,
+                     psConfig->ui32RxBufferSize);
 
     return AM_HAL_STATUS_SUCCESS;
 } // am_hal_uart_configure()
+
+uint32_t
+am_hal_uart_configure_fifo(void *pHandle, const am_hal_uart_config_t *psConfig, bool bEnableFIFO)
+{
+    am_hal_uart_state_t *pState = (am_hal_uart_state_t *) pHandle;
+    uint32_t ui32Module = pState->ui32Module;
+
+    uint32_t ui32ErrorStatus;
+
+    //
+    // Check to make sure this is a valid handle.
+    //
+    if (!AM_HAL_UART_CHK_HANDLE(pHandle))
+    {
+        return AM_HAL_STATUS_INVALID_HANDLE;
+    }
+
+    //
+    // Reset the CR register to a known value.
+    //
+    UARTn(ui32Module)->CR = 0;
+
+    //
+    // Start by enabling the clocks, which needs to happen in a critical
+    // section.
+    //
+    AM_CRITICAL_BEGIN
+
+    UARTn(ui32Module)->CR_b.CLKEN = 1;
+    UARTn(ui32Module)->CR_b.CLKSEL = UART0_CR_CLKSEL_24MHZ;
+
+    AM_CRITICAL_END
+
+    //
+    // Disable the UART.
+    //
+    AM_CRITICAL_BEGIN
+
+    UARTn(ui32Module)->CR_b.UARTEN = 0;
+    UARTn(ui32Module)->CR_b.RXE = 0;
+    UARTn(ui32Module)->CR_b.TXE = 0;
+
+    AM_CRITICAL_END
+
+    //
+    // Set the baud rate.
+    //
+    ui32ErrorStatus = config_baudrate(ui32Module, psConfig->ui32BaudRate,
+                                          &(pState->ui32BaudRate));
+
+    RETURN_ON_ERROR(ui32ErrorStatus);
+
+    //
+    // Copy the configuration options into the appropriate registers.
+    //
+    UARTn(ui32Module)->CR_b.RTSEN = 0;
+    UARTn(ui32Module)->CR_b.CTSEN = 0;
+    UARTn(ui32Module)->CR |= psConfig->ui32FlowControl;
+
+    UARTn(ui32Module)->IFLS = psConfig->ui32FifoLevels;
+
+    UARTn(ui32Module)->LCRH = (psConfig->ui32DataBits   |
+                               psConfig->ui32Parity     |
+                               psConfig->ui32StopBits   |
+                               ((bEnableFIFO) ? AM_HAL_UART_FIFO_ENABLE : AM_HAL_UART_FIFO_DISABLE));
+
+    //
+    // Enable the UART, RX, and TX.
+    //
+    AM_CRITICAL_BEGIN
+
+    UARTn(ui32Module)->CR_b.UARTEN = 1;
+    UARTn(ui32Module)->CR_b.RXE = 1;
+    UARTn(ui32Module)->CR_b.TXE = 1;
+
+    AM_CRITICAL_END
+
+    if(bEnableFIFO){
+        //
+        // Set up any buffers that might exist.
+        //
+        buffer_configure(pHandle,
+                        psConfig->pui8TxBuffer,
+                        psConfig->ui32TxBufferSize,
+                        psConfig->pui8RxBuffer,
+                        psConfig->ui32RxBufferSize);
+    }
+
+    return AM_HAL_STATUS_SUCCESS;
+} // am_hal_uart_configure_fifo()
 
 //*****************************************************************************
 //

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/mcu/apollo3/hal/am_hal_uart.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/sdk/mcu/apollo3/hal/am_hal_uart.h
@@ -312,6 +312,10 @@ extern uint32_t am_hal_uart_power_control(void *pHandle,
 extern uint32_t am_hal_uart_configure(void *pHandle,
                                       const am_hal_uart_config_t *psConfig);
 
+extern uint32_t am_hal_uart_configure_fifo(void *pHandle,
+                                      const am_hal_uart_config_t *psConfig,
+                                      bool bEnableFIFO);
+
 //*****************************************************************************
 //
 //! @brief Transfer data through the UART interface.


### PR DESCRIPTION
Major changes:

-made certain parts of the init only happen on the first init
-comment out (is this the best option) part of ambiq hal that "sets up buffer" and disables interrupts if we arent using hal buffer
-change hal to use AM_HAL_UART_FIFO_DISABLE because i couldn't find a threshold that would allow the interrupt to fire on each byte otherwise
-serial_irq_set fixed to enable and disable individual interrupts
-remove fluff, TODO's, and temp code.

outstanding questions
-add FC or remove TODO's?
