### PR TITLE
Added LoRa Thing Plus, removed other accidental changes

### DIFF
--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/PinNames.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/PinNames.h
@@ -1,0 +1,129 @@
+/* 
+ * Copyright (c) 2019-2020 SparkFun Electronics
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "am_bsp.h"
+#include "objects_gpio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define NC_VAL (int)0xFFFFFFFF
+
+typedef enum
+{
+    // Digital naming
+    D0 = 19,
+    D1 = 18,
+    D2 = 41,
+    D3 = 31,
+    D4 = 10,
+    D5 = 30,
+    D6 = 37,
+    D7 = 24,
+    D8 = 46,
+    D9 = 33,
+    D10 = 48,
+    D11 = 28,
+    D12 = 25, //SDA2
+    D13 = 27, //SCL2
+    D14 = 6,
+    D15 = 5,
+    D16 = 9, //SDA1
+    D17 = 8, //SCL1
+    D18 = 26,
+    D19 = 13,
+    D20 = 12,
+    D21 = 32,
+	D22 = 35,
+	D23 = 34,
+	D24 = 11,
+	
+	//LoRa reserved pins (internal)
+	D36 = 36, //RADIO NSS
+	D38 = 38, //RADIO_MOSI
+	D39 = 39, //RADIO_BUSY
+	D40 = 40, //RADIO_DIO1
+	D42 = 42, //RADIO_CLK
+	D43 = 43, //RADIO_MISO
+	D44 = 44, //RADIO_nRESET
+	D47 = 47, //RADIO_DIO3
+
+    // Analog naming
+    A0 = D19,
+    A1 = D20,
+    A2 = D21,
+    A3 = D22,
+    A4 = D23,
+    A5 = D24,
+    A6 = D3,
+	A7 = D9,
+
+    //BUTTONs
+    SW1 = AM_BSP_GPIO_BUTTON0,
+    
+    // LEDs
+    LED_BLUE = AM_BSP_GPIO_LED0,
+
+    // mbed original LED naming
+
+    LED1 = AM_BSP_GPIO_LED0,
+    
+
+    // I2C
+    I2C_SCL = AM_BSP_QWIIC_I2C_SCL_PIN,
+    I2C_SDA = AM_BSP_QWIIC_I2C_SDA_PIN,
+
+    // Qwiic
+    QWIIC_SCL = I2C_SCL,
+    QWIIC_SDA = I2C_SDA,
+
+    // SPI
+    SPI_CLK = AM_BSP_PRIM_SPI_CLK_PIN,
+    SPI_SDO = AM_BSP_PRIM_SPI_SDO_PIN,
+    SPI_SDI = AM_BSP_PRIM_SPI_SDI_PIN,
+
+    // UART
+    SERIAL_TX = AM_BSP_PRIM_UART_TX_PIN,
+    SERIAL_RX = AM_BSP_PRIM_UART_RX_PIN,
+    USBTX = SERIAL_TX,
+    USBRX = SERIAL_RX,
+
+    SERIAL1_TX = D1,
+    SERIAL1_RX = D0,
+
+    // Not connected
+    NC = NC_VAL
+} PinName;
+
+#define STDIO_UART_TX USBTX
+#define STDIO_UART_RX USBRX
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp.c
@@ -1,0 +1,1063 @@
+//*****************************************************************************
+//
+//  am_bsp.c
+//! @file
+//!
+//! @brief Top level functions for performing board initialization.
+//!
+//! @addtogroup BSP Board Support Package (BSP)
+//! @addtogroup apollo3_eb_bsp BSP for the Apollo3 Engineering Board
+//! @ingroup BSP
+//! @{
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2019, Ambiq Micro
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// Third party software included in this distribution is subject to the
+// additional license terms as defined in the /docs/licenses directory.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision v2.0.0 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "am_bsp.h"
+#include "am_util.h"
+
+//*****************************************************************************
+//
+// Power tracking structures for IOM and UART
+//
+//*****************************************************************************
+am_bsp_uart_pwrsave_t am_bsp_uart_pwrsave[AM_REG_UART_NUM_MODULES];
+
+//*****************************************************************************
+//
+// LEDs
+//
+//*****************************************************************************
+#ifdef AM_BSP_NUM_LEDS
+am_devices_led_t am_bsp_psLEDs[AM_BSP_NUM_LEDS] =
+{
+    {AM_BSP_GPIO_LED0, AM_DEVICES_LED_ON_HIGH | AM_DEVICES_LED_POL_DIRECT_DRIVE_M},
+};
+#endif
+
+#ifdef AM_BSP_NUM_BUTTONS
+//*****************************************************************************
+//
+// Buttons.
+//
+//*****************************************************************************
+am_devices_button_t am_bsp_psButtons[AM_BSP_NUM_BUTTONS] =
+{
+    AM_DEVICES_BUTTON(AM_BSP_GPIO_BUTTON0, AM_DEVICES_BUTTON_NORMAL_HIGH)
+};
+#endif
+
+//*****************************************************************************
+//
+// Print interface tracking variable.
+//
+//*****************************************************************************
+static uint32_t g_ui32PrintInterface = AM_BSP_PRINT_INFC_UART0;
+
+//*****************************************************************************
+//
+// Default UART configuration settings.
+//
+//*****************************************************************************
+static void *g_sCOMUART;
+
+static const am_hal_uart_config_t g_sBspUartConfig =
+{
+    //
+    // Standard UART settings: 115200-8-N-1
+    //
+    .ui32BaudRate = 115200,
+    .ui32DataBits = AM_HAL_UART_DATA_BITS_8,
+    .ui32Parity = AM_HAL_UART_PARITY_NONE,
+    .ui32StopBits = AM_HAL_UART_ONE_STOP_BIT,
+    .ui32FlowControl = AM_HAL_UART_FLOW_CTRL_NONE,
+
+    //
+    // Set TX and RX FIFOs to interrupt at half-full.
+    //
+    .ui32FifoLevels = (AM_HAL_UART_TX_FIFO_1_2 |
+                       AM_HAL_UART_RX_FIFO_1_2),
+
+    //
+    // The default interface will just use polling instead of buffers.
+    //
+    .pui8TxBuffer = 0,
+    .ui32TxBufferSize = 0,
+    .pui8RxBuffer = 0,
+    .ui32RxBufferSize = 0,
+};
+
+#ifndef AM_BSP_DISABLE_BUFFERED_UART
+//*****************************************************************************
+//
+// Default UART configuration settings if using buffers.
+//
+//*****************************************************************************
+#define AM_BSP_UART_BUFFER_SIZE     1024
+static uint8_t pui8UartTxBuffer[AM_BSP_UART_BUFFER_SIZE];
+static uint8_t pui8UartRxBuffer[AM_BSP_UART_BUFFER_SIZE];
+
+static am_hal_uart_config_t g_sBspUartBufferedConfig =
+{
+    //
+    // Standard UART settings: 115200-8-N-1
+    //
+    .ui32BaudRate = 115200,
+    .ui32DataBits = AM_HAL_UART_DATA_BITS_8,
+    .ui32Parity = AM_HAL_UART_PARITY_NONE,
+    .ui32StopBits = AM_HAL_UART_ONE_STOP_BIT,
+    .ui32FlowControl = AM_HAL_UART_FLOW_CTRL_NONE,
+
+    //
+    // Set TX and RX FIFOs to interrupt at half-full.
+    //
+    .ui32FifoLevels = (AM_HAL_UART_TX_FIFO_1_2 |
+                       AM_HAL_UART_RX_FIFO_1_2),
+
+    //
+    // The default interface will just use polling instead of buffers.
+    //
+    .pui8TxBuffer = pui8UartTxBuffer,
+    .ui32TxBufferSize = sizeof(pui8UartTxBuffer),
+    .pui8RxBuffer = pui8UartRxBuffer,
+    .ui32RxBufferSize = sizeof(pui8UartRxBuffer),
+};
+#endif // AM_BSP_DISABLE_BUFFERED_UART
+
+//*****************************************************************************
+//
+//! @brief Prepare the MCU for low power operation.
+//!
+//! This function enables several power-saving features of the MCU, and
+//! disables some of the less-frequently used peripherals. It also sets the
+//! system clock to 24 MHz.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_low_power_init(void)
+{
+    //
+    // Initialize for low power in the power control block
+    //
+    am_hal_pwrctrl_low_power_init();
+
+    //
+    // Disable the RTC.
+    //
+    am_hal_rtc_osc_disable();
+
+    //
+    // Stop the XTAL.
+    //
+    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_XTAL_STOP, 0);
+
+    //
+    // Make sure SWO/ITM/TPIU is disabled.
+    // SBL may not get it completely shut down.
+    //
+    am_bsp_itm_printf_disable();
+
+#ifdef AM_BSP_NUM_LEDS
+    //
+    // Initialize the LEDs.
+    // On the apollo3_evb, when the GPIO outputs are disabled (the default at
+    // power up), the FET gates are floating and partially illuminating the LEDs.
+    //
+    uint32_t ux, ui32GPIONumber;
+    for (ux = 0; ux < AM_BSP_NUM_LEDS; ux++)
+    {
+        ui32GPIONumber = am_bsp_psLEDs[ux].ui32GPIONumber;
+
+        //
+        // Configure the pin as a push-pull GPIO output
+        // (aka AM_DEVICES_LED_POL_DIRECT_DRIVE_M).
+        //
+        am_hal_gpio_pinconfig(ui32GPIONumber, g_AM_HAL_GPIO_OUTPUT);
+
+        //
+        // Turn off the LED.
+        //
+        am_hal_gpio_state_write(ui32GPIONumber, AM_HAL_GPIO_OUTPUT_TRISTATE_DISABLE);
+        am_hal_gpio_state_write(ui32GPIONumber, AM_HAL_GPIO_OUTPUT_CLEAR);
+    }
+#endif // AM_BSP_NUM_LEDS
+
+} // am_bsp_low_power_init()
+
+//*****************************************************************************
+//
+//! @brief Enable the TPIU and ITM for debug printf messages.
+//!
+//! This function enables TPIU registers for debug printf messages and enables
+//! ITM GPIO pin to SWO mode. This function should be called after reset and
+//! after waking up from deep sleep.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_debug_printf_enable(void)
+{
+    if (g_ui32PrintInterface == AM_BSP_PRINT_INFC_SWO)
+    {
+#ifdef AM_BSP_GPIO_ITM_SWO
+        am_bsp_itm_printf_enable();
+#endif
+    }
+    else if (g_ui32PrintInterface == AM_BSP_PRINT_INFC_UART0)
+    {
+        am_bsp_uart_printf_enable();
+    }
+#ifndef AM_BSP_DISABLE_BUFFERED_UART
+    else if (g_ui32PrintInterface == AM_BSP_PRINT_INFC_BUFFERED_UART0)
+    {
+        am_bsp_buffered_uart_printf_enable();
+    }
+#endif // AM_BSP_DISABLE_BUFFERED_UART
+} // am_bsp_debug_printf_enable()
+
+//*****************************************************************************
+//
+//! @brief Enable the TPIU and ITM for debug printf messages.
+//!
+//! This function disables TPIU registers for debug printf messages and
+//! enables ITM GPIO pin to GPIO mode and prepares the MCU to go to deep sleep.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_debug_printf_disable(void)
+{
+    if (g_ui32PrintInterface == AM_BSP_PRINT_INFC_SWO)
+    {
+        am_bsp_itm_printf_disable();
+    }
+    else if (g_ui32PrintInterface == AM_BSP_PRINT_INFC_UART0)
+    {
+        am_bsp_uart_printf_disable();
+    }
+} // am_bsp_debug_printf_disable()
+
+//*****************************************************************************
+//
+// @brief Enable printing over ITM.
+//
+//*****************************************************************************
+void
+#ifdef AM_BSP_GPIO_ITM_SWO
+am_bsp_itm_printf_enable(void)
+#else
+am_bsp_itm_printf_enable(uint32_t ui32Pin, am_hal_gpio_pincfg_t sPincfg)
+#endif
+{
+    am_hal_tpiu_config_t TPIUcfg;
+
+    //
+    // Set the global print interface.
+    //
+    g_ui32PrintInterface = AM_BSP_PRINT_INFC_SWO;
+
+    //
+    // Enable the ITM interface and the SWO pin.
+    //
+    am_hal_itm_enable();
+
+    //
+    // Enable the ITM and TPIU
+    // Set the BAUD clock for 1M
+    //
+    TPIUcfg.ui32SetItmBaud = AM_HAL_TPIU_BAUD_2M;
+    am_hal_tpiu_enable(&TPIUcfg);
+    #ifdef AM_BSP_GPIO_ITM_SWO
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_ITM_SWO, g_AM_BSP_GPIO_ITM_SWO);
+    #else
+    am_hal_gpio_pinconfig(ui32Pin, sPincfg);
+    #endif
+
+    //
+    // Attach the ITM to the STDIO driver.
+    //
+    am_util_stdio_printf_init(am_hal_itm_print);
+} // am_bsp_itm_printf_enable()
+
+//*****************************************************************************
+//
+//! @brief ITM-based string print function.
+//!
+//! This function is used for printing a string via the ITM.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_itm_string_print(char *pcString)
+{
+    am_hal_itm_print(pcString);
+}
+
+//*****************************************************************************
+//
+// @brief Disable printing over ITM.
+//
+//*****************************************************************************
+void
+am_bsp_itm_printf_disable(void)
+{
+    //
+    // Disable the ITM/TPIU
+    //
+    am_hal_itm_disable();
+
+    //
+    // Detach the ITM interface from the STDIO driver.
+    //
+    am_util_stdio_printf_init(0);
+
+    // //
+    // // Disconnect the SWO pin
+    // //
+    // am_hal_gpio_pinconfig(AM_BSP_GPIO_ITM_SWO, g_AM_HAL_GPIO_DISABLE);
+} // am_bsp_itm_printf_disable()
+
+//*****************************************************************************
+//
+//! @brief Set up the IOM pins based on mode and module.
+//!
+//! This function configures up to 10-pins for MSPI serial, dual, quad,
+//! dual-quad, and octal operation.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_iom_pins_enable(uint32_t ui32Module, am_hal_iom_mode_e eIOMMode)
+{
+    uint32_t ui32Combined;
+
+    //
+    // Validate parameters
+    //
+    if ( ui32Module >= AM_REG_IOM_NUM_MODULES )
+    {
+        //
+        // FPGA supports only IOM0 and 1.
+        //
+        return;
+    }
+
+    ui32Combined = ((ui32Module << 2) | eIOMMode);
+
+    switch ( ui32Combined )
+    {
+        case ((0 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SCK,  g_AM_BSP_GPIO_IOM0_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MISO, g_AM_BSP_GPIO_IOM0_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MOSI, g_AM_BSP_GPIO_IOM0_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_CS,   g_AM_BSP_GPIO_IOM0_CS);
+            break;
+
+        case ((1 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_SCK,  g_AM_BSP_GPIO_IOM1_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_MISO, g_AM_BSP_GPIO_IOM1_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_MOSI, g_AM_BSP_GPIO_IOM1_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_CS,   g_AM_BSP_GPIO_IOM1_CS);
+            break;
+
+        case ((2 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_SCK,  g_AM_BSP_GPIO_IOM2_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_MISO, g_AM_BSP_GPIO_IOM2_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_MOSI, g_AM_BSP_GPIO_IOM2_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_CS,   g_AM_BSP_GPIO_IOM2_CS);
+            break;
+
+        case ((3 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_SCK,  g_AM_BSP_GPIO_IOM3_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_MISO, g_AM_BSP_GPIO_IOM3_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_MOSI, g_AM_BSP_GPIO_IOM3_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_CS,   g_AM_BSP_GPIO_IOM3_CS);
+            break;
+
+        case ((4 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SCK,  g_AM_BSP_GPIO_IOM4_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_MISO, g_AM_BSP_GPIO_IOM4_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_MOSI, g_AM_BSP_GPIO_IOM4_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_CS,   g_AM_BSP_GPIO_IOM4_CS);
+            break;
+
+        case ((5 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_SCK,  g_AM_BSP_GPIO_IOM5_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_MISO, g_AM_BSP_GPIO_IOM5_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_MOSI, g_AM_BSP_GPIO_IOM5_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_CS,   g_AM_BSP_GPIO_IOM5_CS);
+            break;
+
+        case ((0 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SCL,  g_AM_BSP_GPIO_IOM0_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SDA,  g_AM_BSP_GPIO_IOM0_SDA);
+            break;
+
+        case ((1 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_SCL,  g_AM_BSP_GPIO_IOM1_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_SDA,  g_AM_BSP_GPIO_IOM1_SDA);
+            break;
+
+        case ((2 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_SCL,  g_AM_BSP_GPIO_IOM2_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_SDA,  g_AM_BSP_GPIO_IOM2_SDA);
+            break;
+
+        case ((3 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_SCL,  g_AM_BSP_GPIO_IOM3_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_SDA,  g_AM_BSP_GPIO_IOM3_SDA);
+            break;
+
+        case ((4 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SCL,  g_AM_BSP_GPIO_IOM4_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SDA,  g_AM_BSP_GPIO_IOM4_SDA);
+            break;
+
+        case ((5 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_SCL,  g_AM_BSP_GPIO_IOM5_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_SDA,  g_AM_BSP_GPIO_IOM5_SDA);
+            break;
+
+        default:
+            break;
+    }
+} // am_bsp_iom_pins_enable()
+
+//*****************************************************************************
+//
+//! @brief Disable the IOM pins based on mode and module.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_iom_pins_disable(uint32_t ui32Module, am_hal_iom_mode_e eIOMMode)
+{
+    uint32_t ui32Combined;
+
+    //
+    // Validate parameters
+    //
+    if ( ui32Module >= AM_REG_IOM_NUM_MODULES )
+    {
+        //
+        // FPGA supports only IOM0 and 1.
+        //
+        return;
+    }
+
+    ui32Combined = ((ui32Module << 2) | eIOMMode);
+
+    switch ( ui32Combined )
+    {
+        case ((0 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_CS,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((1 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_CS,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((2 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_CS,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((3 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_CS,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((4 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_CS,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((5 << 2) | AM_HAL_IOM_SPI_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_CS,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((0 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM0_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((1 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM1_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((2 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM2_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((3 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM3_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((4 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM4_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((5 << 2) | AM_HAL_IOM_I2C_MODE):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOM5_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+        default:
+            break;
+    }
+} // am_bsp_iom_pins_disable()
+
+//*****************************************************************************
+//
+//! @brief Set up the MSPI pins based on the external flash device type.
+//!
+//! This function configures up to 10-pins for MSPI serial, dual, quad,
+//! dual-quad, and octal operation.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_mspi_pins_enable(am_hal_mspi_device_e eMSPIDevice)
+{
+    switch ( eMSPIDevice )
+    {
+        case AM_HAL_MSPI_FLASH_SERIAL_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_BSP_GPIO_MSPI_CE0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_BSP_GPIO_MSPI_D0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_BSP_GPIO_MSPI_D1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_SERIAL_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_BSP_GPIO_MSPI_CE1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_BSP_GPIO_MSPI_D4);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_BSP_GPIO_MSPI_D5);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_DUAL_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_BSP_GPIO_MSPI_CE0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_BSP_GPIO_MSPI_D0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_BSP_GPIO_MSPI_D1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_DUAL_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_BSP_GPIO_MSPI_CE1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_BSP_GPIO_MSPI_D4);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_BSP_GPIO_MSPI_D5);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_QUAD_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_BSP_GPIO_MSPI_CE0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_BSP_GPIO_MSPI_D0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_BSP_GPIO_MSPI_D1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_BSP_GPIO_MSPI_D2);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_BSP_GPIO_MSPI_D3);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_QUAD_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_BSP_GPIO_MSPI_CE1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_BSP_GPIO_MSPI_D4);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_BSP_GPIO_MSPI_D5);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_BSP_GPIO_MSPI_D6);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_BSP_GPIO_MSPI_D7);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_OCTAL_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_BSP_GPIO_MSPI_CE0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_BSP_GPIO_MSPI_D0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_BSP_GPIO_MSPI_D1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_BSP_GPIO_MSPI_D2);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_BSP_GPIO_MSPI_D3);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_BSP_GPIO_MSPI_D4);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_BSP_GPIO_MSPI_D5);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_BSP_GPIO_MSPI_D6);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_BSP_GPIO_MSPI_D7);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_OCTAL_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_BSP_GPIO_MSPI_CE1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_BSP_GPIO_MSPI_D0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_BSP_GPIO_MSPI_D1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_BSP_GPIO_MSPI_D2);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_BSP_GPIO_MSPI_D3);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_BSP_GPIO_MSPI_D4);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_BSP_GPIO_MSPI_D5);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_BSP_GPIO_MSPI_D6);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_BSP_GPIO_MSPI_D7);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+        case AM_HAL_MSPI_FLASH_QUADPAIRED:
+        case AM_HAL_MSPI_FLASH_QUADPAIRED_SERIAL:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_BSP_GPIO_MSPI_CE0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_BSP_GPIO_MSPI_CE1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_BSP_GPIO_MSPI_D0);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_BSP_GPIO_MSPI_D1);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_BSP_GPIO_MSPI_D2);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_BSP_GPIO_MSPI_D3);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_BSP_GPIO_MSPI_D4);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_BSP_GPIO_MSPI_D5);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_BSP_GPIO_MSPI_D6);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_BSP_GPIO_MSPI_D7);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_BSP_GPIO_MSPI_SCK);
+            break;
+    }
+} // am_bsp_mspi_pins_enable()
+
+//*****************************************************************************
+//
+//! @brief Disable the MSPI pins based on the external flash device type.
+//!
+//! This function configures up to 10-pins for MSPI serial, dual, quad,
+//! dual-quad, and octal operation.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_mspi_pins_disable(am_hal_mspi_device_e eMSPIDevice)
+{
+    switch ( eMSPIDevice )
+    {
+        case AM_HAL_MSPI_FLASH_SERIAL_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_SERIAL_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_DUAL_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_DUAL_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_QUAD_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_QUAD_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_OCTAL_CE0:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_OCTAL_CE1:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+        case AM_HAL_MSPI_FLASH_QUADPAIRED:
+        case AM_HAL_MSPI_FLASH_QUADPAIRED_SERIAL:
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE0, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_CE1, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D0,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D1,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D2,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D3,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D4,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D5,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D6,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_D7,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_MSPI_SCK, g_AM_HAL_GPIO_DISABLE);
+            break;
+    }
+} // am_bsp_mspi_pins_disable()
+
+//*****************************************************************************
+//
+//! @brief Set up the IOS pins based on mode and module.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void am_bsp_ios_pins_enable(uint32_t ui32Module, uint32_t ui32IOSMode)
+{
+    uint32_t ui32Combined;
+
+    //
+    // Validate parameters
+    //
+    if ( ui32Module >= AM_REG_IOSLAVE_NUM_MODULES )
+    {
+        return;
+    }
+
+    ui32Combined = ((ui32Module << 2) | ui32IOSMode);
+
+    switch ( ui32Combined )
+    {
+        case ((0 << 2) | AM_HAL_IOS_USE_SPI):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_SCK,  g_AM_BSP_GPIO_IOS_SCK);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_MISO, g_AM_BSP_GPIO_IOS_MISO);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_MOSI, g_AM_BSP_GPIO_IOS_MOSI);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_CE,   g_AM_BSP_GPIO_IOS_CE);
+            break;
+
+        case ((0 << 2) | AM_HAL_IOS_USE_I2C):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_SCL,  g_AM_BSP_GPIO_IOS_SCL);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_SDA,  g_AM_BSP_GPIO_IOS_SDA);
+            break;
+        default:
+            break;
+    }
+} // am_bsp_ios_pins_enable()
+
+//*****************************************************************************
+//
+//! @brief Disable the IOS pins based on mode and module.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void am_bsp_ios_pins_disable(uint32_t ui32Module, uint32_t ui32IOSMode)
+{
+    uint32_t ui32Combined;
+
+    //
+    // Validate parameters
+    //
+    if ( ui32Module >= AM_REG_IOSLAVE_NUM_MODULES )
+    {
+        return;
+    }
+
+    ui32Combined = ((ui32Module << 2) | ui32IOSMode);
+
+    switch ( ui32Combined )
+    {
+        case ((0 << 2) | AM_HAL_IOS_USE_SPI):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_SCK,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_MISO, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_MOSI, g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_CE,   g_AM_HAL_GPIO_DISABLE);
+            break;
+
+        case ((0 << 2) | AM_HAL_IOS_USE_I2C):
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_SCL,  g_AM_HAL_GPIO_DISABLE);
+            am_hal_gpio_pinconfig(AM_BSP_GPIO_IOS_SDA,  g_AM_HAL_GPIO_DISABLE);
+            break;
+        default:
+            break;
+    }
+} // am_bsp_ios_pins_disable()
+
+//*****************************************************************************
+//
+//! @brief UART-based string print function.
+//!
+//! This function is used for printing a string via the UART, which for some
+//! MCU devices may be multi-module.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+am_bsp_uart_string_print(char *pcString)
+{
+    uint32_t ui32StrLen = 0;
+    uint32_t ui32BytesWritten = 0;
+
+    //
+    // Measure the length of the string.
+    //
+    while (pcString[ui32StrLen] != 0)
+    {
+        ui32StrLen++;
+    }
+
+    //
+    // Print the string via the UART.
+    //
+    const am_hal_uart_transfer_t sUartWrite =
+    {
+        .ui32Direction = AM_HAL_UART_WRITE,
+        .pui8Data = (uint8_t *) pcString,
+        .ui32NumBytes = ui32StrLen,
+        .ui32TimeoutMs = AM_HAL_UART_WAIT_FOREVER,
+        .pui32BytesTransferred = &ui32BytesWritten,
+    };
+
+    am_hal_uart_transfer(g_sCOMUART, &sUartWrite);
+
+    if (ui32BytesWritten != ui32StrLen)
+    {
+        //
+        // Couldn't send the whole string!!
+        //
+        while(1);
+    }
+} // am_bsp_uart_string_print()
+
+//*****************************************************************************
+//
+// Pass-through function to let applications access the COM UART.
+//
+//*****************************************************************************
+uint32_t
+am_bsp_com_uart_transfer(const am_hal_uart_transfer_t *psTransfer)
+{
+    return am_hal_uart_transfer(g_sCOMUART, psTransfer);
+} // am_bsp_com_uart_transfer()
+
+//*****************************************************************************
+//
+// Initialize and configure the UART
+//
+//*****************************************************************************
+void
+am_bsp_uart_printf_enable(void)
+{
+    //
+    // Save the information that we're using the UART for printing.
+    //
+    g_ui32PrintInterface = AM_BSP_PRINT_INFC_UART0;
+
+    //
+    // Initialize, power up, and configure the communication UART. Use the
+    // custom configuration if it was provided. Otherwise, just use the default
+    // configuration.
+    //
+    am_hal_uart_initialize(AM_BSP_UART_PRINT_INST, &g_sCOMUART);
+    am_hal_uart_power_control(g_sCOMUART, AM_HAL_SYSCTRL_WAKE, false);
+    am_hal_uart_configure(g_sCOMUART, &g_sBspUartConfig);
+
+    //
+    // Enable the UART pins.
+    //
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_TX, g_AM_BSP_GPIO_COM_UART_TX);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_RX, g_AM_BSP_GPIO_COM_UART_RX);
+
+    //
+    // Register the BSP print function to the STDIO driver.
+    //
+    am_util_stdio_printf_init(am_bsp_uart_string_print);
+} // am_bsp_uart_printf_enable()
+
+//*****************************************************************************
+//
+// Initialize and configure the UART with a custom configuration
+//
+//*****************************************************************************
+void
+am_bsp_uart_printf_enable_custom(const am_hal_uart_config_t* p_config)
+{
+    //
+    // Save the information that we're using the UART for printing.
+    //
+    g_ui32PrintInterface = AM_BSP_PRINT_INFC_UART0;
+
+    //
+    // Initialize, power up, and configure the communication UART. Use the
+    // custom configuration if it was provided. Otherwise, just use the default
+    // configuration.
+    //
+    am_hal_uart_initialize(AM_BSP_UART_PRINT_INST, &g_sCOMUART);
+    am_hal_uart_power_control(g_sCOMUART, AM_HAL_SYSCTRL_WAKE, false);
+    am_hal_uart_configure(g_sCOMUART, p_config);
+
+    //
+    // Enable the UART pins.
+    //
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_TX, g_AM_BSP_GPIO_COM_UART_TX);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_RX, g_AM_BSP_GPIO_COM_UART_RX);
+
+    //
+    // Register the BSP print function to the STDIO driver.
+    //
+    am_util_stdio_printf_init(am_bsp_uart_string_print);
+} // am_bsp_uart_printf_enable()
+
+//*****************************************************************************
+//
+// Disable the UART
+//
+//*****************************************************************************
+void
+am_bsp_uart_printf_disable(void)
+{
+    //
+    // Make sure the UART has finished sending everything it's going to send.
+    //
+    am_hal_uart_tx_flush(g_sCOMUART);
+
+    //
+    // Detach the UART from the stdio driver.
+    //
+    am_util_stdio_printf_init(0);
+
+    //
+    // Power down the UART, and surrender the handle.
+    //
+    am_hal_uart_power_control(g_sCOMUART, AM_HAL_SYSCTRL_DEEPSLEEP, false);
+    am_hal_uart_deinitialize(g_sCOMUART);
+
+    //
+    // Disable the UART pins.
+    //
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_TX, g_AM_HAL_GPIO_DISABLE);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_RX, g_AM_HAL_GPIO_DISABLE);
+
+} // am_bsp_uart_printf_disable()
+
+#ifndef AM_BSP_DISABLE_BUFFERED_UART
+//*****************************************************************************
+//
+// Initialize and configure the UART
+//
+//*****************************************************************************
+void
+am_bsp_buffered_uart_printf_enable(void)
+{
+    //
+    // Save the information that we're using the UART for printing.
+    //
+    g_ui32PrintInterface = AM_BSP_PRINT_INFC_UART0;
+
+    //
+    // Initialize, power up, and configure the communication UART. Use the
+    // custom configuration if it was provided. Otherwise, just use the default
+    // configuration.
+    //
+    am_hal_uart_initialize(AM_BSP_UART_PRINT_INST, &g_sCOMUART);
+    am_hal_uart_power_control(g_sCOMUART, AM_HAL_SYSCTRL_WAKE, false);
+    am_hal_uart_configure(g_sCOMUART, &g_sBspUartBufferedConfig);
+
+    //
+    // Enable the UART pins.
+    //
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_TX, g_AM_BSP_GPIO_COM_UART_TX);
+    am_hal_gpio_pinconfig(AM_BSP_GPIO_COM_UART_RX, g_AM_BSP_GPIO_COM_UART_RX);
+
+    //
+    // Register the BSP print function to the STDIO driver.
+    //
+    am_util_stdio_printf_init(am_bsp_uart_string_print);
+
+    //
+    // Enable the interrupts for the UART.
+    //
+    NVIC_EnableIRQ((IRQn_Type)(UART0_IRQn + AM_BSP_UART_PRINT_INST));
+} // am_bsp_buffered_uart_printf_enable()
+
+//*****************************************************************************
+//
+// Interrupt routine for the buffered UART interface.
+//
+//*****************************************************************************
+void
+am_bsp_buffered_uart_service(void)
+{
+    uint32_t ui32Status, ui32Idle;
+    am_hal_uart_interrupt_status_get(g_sCOMUART, &ui32Status, true);
+    am_hal_uart_interrupt_clear(g_sCOMUART, ui32Status);
+    am_hal_uart_interrupt_service(g_sCOMUART, ui32Status, &ui32Idle);
+} // am_bsp_buffered_uart_service()
+#endif // AM_BSP_DISABLE_BUFFERED_UART
+
+
+
+//*****************************************************************************
+//
+// End Doxygen group.
+//! @}
+//
+//*****************************************************************************

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp.h
@@ -1,0 +1,268 @@
+//*****************************************************************************
+//
+//  am_bsp.h
+//! @file
+//!
+//! @brief Functions to aid with configuring the GPIOs.
+//!
+//! @addtogroup BSP Board Support Package (BSP)
+//! @addtogroup apollo3_fpga_bsp BSP for the Apollo3 Hotshot FPGA
+//! @ingroup BSP
+//! @{
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2019, Ambiq Micro
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// Third party software included in this distribution is subject to the
+// additional license terms as defined in the /docs/licenses directory.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision v2.0.0 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef AM_BSP_H
+#define AM_BSP_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "am_mcu_apollo.h"
+#include "am_bsp_pins.h"
+
+//
+// Make individual includes to not require full port before usage.
+//#include "am_devices.h"
+//
+#include "am_devices_led.h"
+#include "am_devices_button.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//*****************************************************************************
+//
+// Begin User Modifiable Area
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// PDM Microphone
+//
+//*****************************************************************************
+#define AM_BSP_PDM_CHANNEL                  AM_HAL_PDM_CHANNEL_RIGHT
+#define AM_BSP_PDM_DATA_PIN                 AM_BSP_GPIO_MIC_DATA
+#define AM_BSP_PDM_CLOCK_PIN                AM_BSP_GPIO_MIC_CLK
+#define g_AM_BSP_PDM_DATA                   g_AM_BSP_GPIO_MIC_DATA
+#define g_AM_BSP_PDM_CLOCK                  g_AM_BSP_GPIO_MIC_CLK
+
+
+//*****************************************************************************
+//
+// Primary SPI Pins
+//
+//*****************************************************************************
+#define AM_BSP_PRIM_SPI_IOM                 2
+#define AM_BSP_PRIM_SPI_CLK_PIN             AM_BSP_GPIO_IOM2_SCK
+#define AM_BSP_PRIM_SPI_SDO_PIN             AM_BSP_GPIO_IOM2_MOSI
+#define AM_BSP_PRIM_SPI_SDI_PIN             AM_BSP_GPIO_IOM2_MISO
+#define g_AM_BSP_PRIM_SPI_CLK               g_AM_BSP_GPIO_IOM2_SCK
+#define g_AM_BSP_PRIM_SPI_SDO               g_AM_BSP_GPIO_IOM2_SDO
+#define g_AM_BSP_PRIM_SPI_SDI               g_AM_BSP_GPIO_IOM2_SDI
+
+
+//*****************************************************************************
+//
+// Primary UART Pins
+//
+//*****************************************************************************
+#define AM_BSP_PRIM_UART_TX_PIN             AM_BSP_GPIO_COM_UART_TX
+#define AM_BSP_PRIM_UART_RX_PIN             AM_BSP_GPIO_COM_UART_RX
+#define g_AM_BSP_PRIM_UART_TX               g_AM_BSP_GPIO_COM_UART_TX
+#define g_AM_BSP_PRIM_UART_RX               g_AM_BSP_GPIO_COM_UART_RX
+
+
+//*****************************************************************************
+//
+// Qwiic Connector.
+//
+//*****************************************************************************
+#define AM_BSP_QWIIC_I2C_IOM                0
+#define AM_BSP_QWIIC_I2C_SDA_PIN            AM_BSP_GPIO_IOM0_SDA
+#define AM_BSP_QWIIC_I2C_SCL_PIN            AM_BSP_GPIO_IOM0_SCL
+#define g_AM_BSP_QWIIC_I2C_SDA              g_AM_BSP_GPIO_IOM0_SDA
+#define g_AM_BSP_QWIIC_I2C_SCL              g_AM_BSP_GPIO_IOM0_SCL
+
+
+//*****************************************************************************
+//
+// Button definitions.
+//
+//*****************************************************************************
+#define AM_BSP_NUM_BUTTONS                  1
+extern am_devices_button_t am_bsp_psButtons[AM_BSP_NUM_BUTTONS];
+
+#define AM_BSP_GPIO_BUTTON10        AM_BSP_GPIO_BUTTON0
+#define AM_BSP_GPIO_SWCH            AM_BSP_GPIO_BUTTON0
+
+
+//*****************************************************************************
+//
+// LED definitions.
+//
+//*****************************************************************************
+#define AM_BSP_NUM_LEDS                   1
+extern am_devices_led_t am_bsp_psLEDs[AM_BSP_NUM_LEDS];
+
+
+// LED Device Array Indices
+#define AM_BSP_LED0 0
+#define AM_BSP_LED_BLUE         AM_BSP_LED0
+
+// Corresponding GPIO Numbers
+#define AM_BSP_GPIO_LED             AM_BSP_GPIO_LED_BLUE
+#define AM_BSP_GPIO_LED0            AM_BSP_GPIO_LED_BLUE
+#define AM_BSP_GPIO_LED18           AM_BSP_GPIO_LED_BLUE
+
+
+//*****************************************************************************
+//
+// PWM_LED peripheral assignments.
+//
+//*****************************************************************************
+//
+// The Artemis Thing Plus PWM LED is pad 26
+//
+#define AM_BSP_PIN_PWM_LED                  AM_BSP_GPIO_LED0
+#define AM_BSP_PWM_LED_TIMER                0
+#define AM_BSP_PWM_LED_TIMER_SEG            AM_HAL_CTIMER_TIMERB
+#define AM_BSP_PWM_LED_TIMER_INT            AM_HAL_CTIMER_INT_TIMERB0C0
+
+//*****************************************************************************
+//
+// UART definitions.
+//
+//*****************************************************************************
+//
+// Apollo3 has two UART instances.
+// AM_BSP_UART_PRINT_INST should correspond to COM_UART.
+//
+#define AM_BSP_UART_IOS_INST                0
+#define AM_BSP_UART_PRINT_INST              0
+#define AM_BSP_UART_BOOTLOADER_INST         0
+
+//*****************************************************************************
+//
+// End User Modifiable Area
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Print interface type
+//
+//*****************************************************************************
+#define AM_BSP_PRINT_INFC_NONE              0
+#define AM_BSP_PRINT_INFC_SWO               1
+#define AM_BSP_PRINT_INFC_UART0             2
+#define AM_BSP_PRINT_INFC_BUFFERED_UART0    3
+
+
+//*****************************************************************************
+//
+//! Structure containing UART configuration information while it is powered down.
+//
+//*****************************************************************************
+typedef struct
+{
+    bool     bSaved;
+    uint32_t ui32TxPinNum;
+    uint32_t ui32TxPinCfg;
+}
+am_bsp_uart_pwrsave_t;
+
+//*****************************************************************************
+//
+// External data definitions.
+//
+//*****************************************************************************
+extern am_bsp_uart_pwrsave_t am_bsp_uart_pwrsave[AM_REG_UART_NUM_MODULES];
+
+//*****************************************************************************
+//
+// External function definitions.
+//
+//*****************************************************************************
+extern void am_bsp_low_power_init(void);
+extern void am_bsp_iom_pins_enable(uint32_t ui32Module, am_hal_iom_mode_e eIOMMode);
+extern void am_bsp_iom_pins_disable(uint32_t ui32Module, am_hal_iom_mode_e eIOMMode);
+extern void am_bsp_mspi_pins_enable(am_hal_mspi_device_e eMSPIDevice);
+extern void am_bsp_mspi_pins_disable(am_hal_mspi_device_e eMSPIDevice);
+
+extern void am_bsp_ios_pins_enable(uint32_t ui32Module, uint32_t ui32IOSMode);   // SparkFun Edge does not expose IO Slave Clock signal, so hiding these functions
+extern void am_bsp_ios_pins_disable(uint32_t ui32Module, uint32_t ui32IOSMode);
+
+extern void am_bsp_debug_printf_enable(void);
+extern void am_bsp_debug_printf_disable(void);
+
+#ifdef AM_BSP_GPIO_ITM_SWO
+extern void am_bsp_itm_printf_enable(void);
+#else
+extern void am_bsp_itm_printf_enable(uint32_t ui32Pin, am_hal_gpio_pincfg_t sPincfg);
+#endif
+extern void am_bsp_itm_string_print(char *pcString);
+extern void am_bsp_itm_printf_disable(void);
+
+extern void am_bsp_uart_string_print(char *pcString);
+extern void am_bsp_uart_printf_enable(void);
+extern void am_bsp_uart_printf_enable_custom(const am_hal_uart_config_t* p_config);
+extern void am_bsp_uart_printf_disable(void);
+
+extern void am_bsp_buffered_uart_printf_enable(void);
+extern void am_bsp_buffered_uart_service(void);
+
+extern uint32_t am_bsp_com_uart_transfer(const am_hal_uart_transfer_t *psTransfer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AM_BSP_H
+//*****************************************************************************
+//
+// End Doxygen group.
+//! @}
+//
+//*****************************************************************************

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp_pins.c
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp_pins.c
@@ -1,0 +1,874 @@
+//*****************************************************************************
+//
+//  am_bsp_pins.c
+//! @file
+//!
+//! @brief BSP pin configuration definitions.
+//!
+//! @addtogroup BSP Board Support Package (BSP)
+//! @addtogroup apollo3_evb_bsp BSP for the Apollo3 Engineering Board
+//! @ingroup BSP
+//! @{
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2019, Ambiq Micro
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// Third party software included in this distribution is subject to the
+// additional license terms as defined in the /docs/licenses directory.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision 2.2.0-hotfix-2.2.1 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "am_bsp.h"
+
+//*****************************************************************************
+//
+//  MIC_DATA pin: Data line for PDM microphones.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MIC_DATA =
+{
+    .uFuncSel            = AM_HAL_PIN_36_PDMDATA
+};
+
+//*****************************************************************************
+//
+//  MIC_CLK pin: Clock line for PDM microphones.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MIC_CLK =
+{
+    .uFuncSel            = AM_HAL_PIN_37_PDMCLK
+};
+
+//*****************************************************************************
+//
+//  LED_BLUE pin: The BLUE LED labelled 18.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_LED_BLUE =
+{
+    .uFuncSel            = AM_HAL_PIN_26_GPIO,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA
+};
+
+//*****************************************************************************
+//
+//  BUTTON0 pin: Labeled 10 on the Artemis Thing Plus.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_BUTTON0 =
+{
+    .uFuncSel            = AM_HAL_PIN_48_GPIO,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_2MA,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_ENABLE
+};
+
+//*****************************************************************************
+//
+//  COM_UART_TX pin: This pin is the COM_UART transmit pin.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_COM_UART_TX =
+{
+    .uFuncSel            = AM_HAL_PIN_22_UART0TX,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_2MA
+};
+
+//*****************************************************************************
+//
+//  COM_UART_RX pin: This pin is the COM_UART receive pin.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_COM_UART_RX =
+{
+    .uFuncSel            = AM_HAL_PIN_23_UART0RX
+};
+
+//*****************************************************************************
+//
+//  IOM0_CS pin: I/O Master 0 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_CS =
+{
+    .uFuncSel            = AM_HAL_PIN_11_NCE11,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 0,
+    .uNCE                = 0,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM0_CS3 pin: I/O Master 0 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_CS3 =
+{
+    .uFuncSel            = AM_HAL_PIN_15_NCE15,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 0,
+    .uNCE                = 3,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM0_MISO pin: I/O Master 0 SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_6_M0MISO,
+    .uIOMnum             = 0
+};
+
+//*****************************************************************************
+//
+//  IOM0_MOSI pin: I/O Master 0 SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_7_M0MOSI,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 0
+};
+
+//*****************************************************************************
+//
+//  IOM0_SCK pin: I/O Master 0 SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_5_M0SCK,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 0
+};
+
+//*****************************************************************************
+//
+//  IOM0_SCL pin: I/O Master 0 I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_5_M0SCL,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 0
+};
+
+//*****************************************************************************
+//
+//  IOM0_SDA pin: I/O Master 0 I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM0_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_6_M0SDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 0
+};
+
+//*****************************************************************************
+//
+//  IOM1_CS pin: I/O Master 1 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM1_CS =
+{
+    .uFuncSel            = AM_HAL_PIN_14_NCE14,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 1,
+    .uNCE                = 2,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM1_MISO pin: I/O Master 1 SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM1_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_9_M1MISO,
+    .uIOMnum             = 1
+};
+
+//*****************************************************************************
+//
+//  IOM1_MOSI pin: I/O Master 1 SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM1_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_10_M1MOSI,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 1
+};
+
+//*****************************************************************************
+//
+//  IOM1_SCK pin: I/O Master 1 SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM1_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_8_M1SCK,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 1
+};
+
+//*****************************************************************************
+//
+//  IOM1_SCL pin: I/O Master 1 I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM1_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_8_M1SCL,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 1
+};
+
+//*****************************************************************************
+//
+//  IOM1_SDA pin: I/O Master 1 I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM1_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_9_M1SDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 1
+};
+
+//*****************************************************************************
+//
+//  IOM2_CS pin: I/O Master 2 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM2_CS =
+{
+    .uFuncSel            = AM_HAL_PIN_15_NCE15,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 2,
+    .uNCE                = 3,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM2_MISO pin: I/O Master 2 SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM2_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_25_M2MISO,
+    .uIOMnum             = 2
+};
+
+//*****************************************************************************
+//
+//  IOM2_MOSI pin: I/O Master 2 SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM2_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_28_M2MOSI,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 2
+};
+
+//*****************************************************************************
+//
+//  IOM2_SCK pin: I/O Master 2 SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM2_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_27_M2SCK,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 2
+};
+
+//*****************************************************************************
+//
+//  IOM2_SCL pin: I/O Master 2 I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM2_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_27_M2SCL,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 2
+};
+
+//*****************************************************************************
+//
+//  IOM2_SDA pin: I/O Master 2 I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM2_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_25_M2SDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 2
+};
+
+//*****************************************************************************
+//
+//  IOM3_CS pin: I/O Master 3 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM3_CS =
+{
+    .uFuncSel            = AM_HAL_PIN_12_NCE12,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 3,
+    .uNCE                = 0,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM3_MISO pin: I/O Master 3 SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM3_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_43_M3MISO,
+    .uIOMnum             = 3
+};
+
+//*****************************************************************************
+//
+//  IOM3_MOSI pin: I/O Master 3 SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM3_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_38_M3MOSI,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 3
+};
+
+//*****************************************************************************
+//
+//  IOM3_SCK pin: I/O Master 3 SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM3_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_42_M3SCK,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 3
+};
+
+//*****************************************************************************
+//
+//  IOM3_SCL pin: I/O Master 3 I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM3_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_42_M3SCL,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 3
+};
+
+//*****************************************************************************
+//
+//  IOM3_SDA pin: I/O Master 3 I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM3_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_43_M3SDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 3
+};
+
+//*****************************************************************************
+//
+//  IOM4_CS pin: I/O Master 4 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM4_CS =
+{
+    .uFuncSel            = AM_HAL_PIN_13_NCE13,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 4,
+    .uNCE                = 1,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM4_MISO pin: I/O Master 4 SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM4_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_40_M4MISO,
+    .uIOMnum             = 4
+};
+
+//*****************************************************************************
+//
+//  IOM4_MOSI pin: I/O Master 4 SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM4_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_44_M4MOSI,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 4
+};
+
+//*****************************************************************************
+//
+//  IOM4_SCK pin: I/O Master 4 SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM4_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_39_M4SCK,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 4
+};
+
+//*****************************************************************************
+//
+//  IOM4_SCL pin: I/O Master 4 I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM4_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_39_M4SCL,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 4
+};
+
+//*****************************************************************************
+//
+//  IOM4_SDA pin: I/O Master 4 I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM4_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_40_M4SDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 4
+};
+
+//*****************************************************************************
+//
+//  IOM5_CS pin: I/O Master 5 chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM5_CS =
+{
+    .uFuncSel            = AM_HAL_PIN_16_NCE16,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 5,
+    .uNCE                = 0,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOM5_MISO pin: I/O Master 5 SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM5_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_49_M5MISO,
+    .uIOMnum             = 5
+};
+
+//*****************************************************************************
+//
+//  IOM5_MOSI pin: I/O Master 5 SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM5_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_47_M5MOSI,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 5
+};
+
+//*****************************************************************************
+//
+//  IOM5_SCK pin: I/O Master 5 SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM5_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_48_M5SCK,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .uIOMnum             = 5
+};
+
+//*****************************************************************************
+//
+//  IOM5_SCL pin: I/O Master 5 I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM5_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_48_M5SCL,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 5
+};
+
+//*****************************************************************************
+//
+//  IOM5_SDA pin: I/O Master 5 I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOM5_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_49_M5SDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN,
+    .uIOMnum             = 5
+};
+
+//*****************************************************************************
+//
+//  MSPI_CE0 pin: MSPI chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_CE0 =
+{
+    .uFuncSel            = AM_HAL_PIN_19_NCE19,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6,
+    .uNCE                = 0,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  MSPI_CE1 pin: MSPI chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_CE1 =
+{
+    .uFuncSel            = AM_HAL_PIN_41_NCE41,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_PUSHPULL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_NONE,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6,
+    .uNCE                = 1,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  MSPI_D0 pin: MSPI data 0.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D0 =
+{
+    .uFuncSel            = AM_HAL_PIN_22_MSPI0,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D1 pin: MSPI data 1.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D1 =
+{
+    .uFuncSel            = AM_HAL_PIN_26_MSPI1,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D2 pin: MSPI data 2.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D2 =
+{
+    .uFuncSel            = AM_HAL_PIN_4_MSPI2,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D3 pin: MSPI data 3.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D3 =
+{
+    .uFuncSel            = AM_HAL_PIN_23_MSPI13,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D4 pin: MSPI data 4.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D4 =
+{
+    .uFuncSel            = AM_HAL_PIN_0_MSPI4,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D5 pin: MSPI data 5.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D5 =
+{
+    .uFuncSel            = AM_HAL_PIN_1_MSPI5,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D6 pin: MSPI data 6.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D6 =
+{
+    .uFuncSel            = AM_HAL_PIN_2_MSPI6,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_D7 pin: MSPI data 7.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_D7 =
+{
+    .uFuncSel            = AM_HAL_PIN_3_MSPI7,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_8MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  MSPI_SCK pin: MSPI clock.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_MSPI_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_24_MSPI8,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA,
+    .eIntDir             = AM_HAL_GPIO_PIN_INTDIR_LO2HI,
+    .uIOMnum             = 6
+};
+
+//*****************************************************************************
+//
+//  IOS_CE pin: I/O Slave chip select.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOS_CE =
+{
+    .uFuncSel            = AM_HAL_PIN_3_SLnCE,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_ENABLE,
+    .uNCE                = 0,
+    .eCEpol              = AM_HAL_GPIO_PIN_CEPOL_ACTIVELOW
+};
+
+//*****************************************************************************
+//
+//  IOS_MISO pin: I/O Slave SPI MISO signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOS_MISO =
+{
+    .uFuncSel            = AM_HAL_PIN_2_SLMISO,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_12MA
+};
+
+//*****************************************************************************
+//
+//  IOS_MOSI pin: I/O Slave SPI MOSI signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOS_MOSI =
+{
+    .uFuncSel            = AM_HAL_PIN_1_SLMOSI,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_ENABLE
+};
+
+//*****************************************************************************
+//
+//  IOS_SCK pin: I/O Slave SPI SCK signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOS_SCK =
+{
+    .uFuncSel            = AM_HAL_PIN_0_SLSCK,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_ENABLE
+};
+
+//*****************************************************************************
+//
+//  IOS_SCL pin: I/O Slave I2C clock signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOS_SCL =
+{
+    .uFuncSel            = AM_HAL_PIN_0_SLSCL,
+    .eGPInput            = AM_HAL_GPIO_PIN_INPUT_ENABLE
+};
+
+//*****************************************************************************
+//
+//  IOS_SDA pin: I/O Slave I2C data signal.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_IOS_SDA =
+{
+    .uFuncSel            = AM_HAL_PIN_1_SLSDAWIR3,
+    .ePullup             = AM_HAL_GPIO_PIN_PULLUP_1_5K,
+    .eGPOutcfg           = AM_HAL_GPIO_PIN_OUTCFG_OPENDRAIN
+};
+
+//*****************************************************************************
+//
+//  ITM_SWO pin: ITM Serial Wire Output.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_ITM_SWO =
+{
+    .uFuncSel            = AM_HAL_PIN_33_SWO,
+    .eDriveStrength      = AM_HAL_GPIO_PIN_DRIVESTRENGTH_2MA
+};
+
+//*****************************************************************************
+//
+//  SWDCK pin: Cortex Serial Wire DCK.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_SWDCK =
+{
+    .uFuncSel            = AM_HAL_PIN_20_SWDCK
+};
+
+//*****************************************************************************
+//
+//  SWDIO pin: Cortex Serial Wire DIO.
+//
+//*****************************************************************************
+const am_hal_gpio_pincfg_t g_AM_BSP_GPIO_SWDIO =
+{
+    .uFuncSel            = AM_HAL_PIN_21_SWDIO
+};
+
+//*****************************************************************************
+//
+// End Doxygen group.
+//! @}
+//
+//*****************************************************************************

--- a/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp_pins.h
+++ b/targets/TARGET_Ambiq_Micro/TARGET_Apollo3/TARGET_LoRa_THING_PLUS_expLoRaBLE/bsp/am_bsp_pins.h
@@ -1,0 +1,577 @@
+//*****************************************************************************
+//
+//  am_bsp_pins.h
+//! @file
+//!
+//! @brief BSP pin configuration definitions.
+//!
+//! @addtogroup BSP Board Support Package (BSP)
+//! @addtogroup apollo3_bsp BSP for the Apollo3 EVB.
+//! @ingroup BSP
+//! @{
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// Copyright (c) 2019, Ambiq Micro
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// Third party software included in this distribution is subject to the
+// additional license terms as defined in the /docs/licenses directory.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// This is part of revision 2.2.0-hotfix-2.2.1 of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef AM_BSP_PINS_H
+#define AM_BSP_PINS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "am_mcu_apollo.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+//*****************************************************************************
+//
+//  LED_BLUE pin: The BLUE LED labelled 18.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_LED_BLUE            	26
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_LED_BLUE;
+
+//*****************************************************************************
+//
+//  BUTTON0 pin: Labeled 10 on the LoRa Thing Plus.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_BUTTON0             	48
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_BUTTON0;
+
+//*****************************************************************************
+//
+//  COM_UART_TX pin: This pin is the COM_UART transmit pin.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_COM_UART_TX         	22
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_COM_UART_TX;
+
+//*****************************************************************************
+//
+//  COM_UART_RX pin: This pin is the COM_UART receive pin.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_COM_UART_RX         	23
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_COM_UART_RX;
+
+//*****************************************************************************
+//
+//  IOM0_CS pin: I/O Master 0 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_CS             	11
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_CS;
+#define AM_BSP_IOM0_CS_CHNL             0
+
+//*****************************************************************************
+//
+//  IOM0_CS3 pin: I/O Master 0 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_CS3            	15
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_CS3;
+#define AM_BSP_IOM0_CS3_CHNL            3
+
+//*****************************************************************************
+//
+//  IOM0_MISO pin: I/O Master 0 SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_MISO           	6
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_MISO;
+
+//*****************************************************************************
+//
+//  IOM0_MOSI pin: I/O Master 0 SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_MOSI           	7
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_MOSI;
+
+//*****************************************************************************
+//
+//  IOM0_SCK pin: I/O Master 0 SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_SCK            	5
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_SCK;
+
+//*****************************************************************************
+//
+//  IOM0_SCL pin: I/O Master 0 I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_SCL            	5
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_SCL;
+
+//*****************************************************************************
+//
+//  IOM0_SDA pin: I/O Master 0 I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM0_SDA            	6
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM0_SDA;
+
+//*****************************************************************************
+//
+//  IOM1_CS pin: I/O Master 1 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM1_CS             	14
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM1_CS;
+#define AM_BSP_IOM1_CS_CHNL             2
+
+//*****************************************************************************
+//
+//  IOM1_MISO pin: I/O Master 1 SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM1_MISO           	9
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM1_MISO;
+
+//*****************************************************************************
+//
+//  IOM1_MOSI pin: I/O Master 1 SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM1_MOSI           	10
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM1_MOSI;
+
+//*****************************************************************************
+//
+//  IOM1_SCK pin: I/O Master 1 SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM1_SCK            	8
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM1_SCK;
+
+//*****************************************************************************
+//
+//  IOM1_SCL pin: I/O Master 1 I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM1_SCL            	8
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM1_SCL;
+
+//*****************************************************************************
+//
+//  IOM1_SDA pin: I/O Master 1 I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM1_SDA            	9
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM1_SDA;
+
+//*****************************************************************************
+//
+//  IOM2_CS pin: I/O Master 2 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM2_CS             	15
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM2_CS;
+#define AM_BSP_IOM2_CS_CHNL             3
+
+//*****************************************************************************
+//
+//  IOM2_MISO pin: I/O Master 2 SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM2_MISO           	25
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM2_MISO;
+
+//*****************************************************************************
+//
+//  IOM2_MOSI pin: I/O Master 2 SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM2_MOSI           	28
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM2_MOSI;
+
+//*****************************************************************************
+//
+//  IOM2_SCK pin: I/O Master 2 SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM2_SCK            	27
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM2_SCK;
+
+//*****************************************************************************
+//
+//  IOM2_SCL pin: I/O Master 2 I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM2_SCL            	27
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM2_SCL;
+
+//*****************************************************************************
+//
+//  IOM2_SDA pin: I/O Master 2 I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM2_SDA            	25
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM2_SDA;
+
+//*****************************************************************************
+//
+//  IOM3_CS pin: I/O Master 3 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM3_CS             	12
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM3_CS;
+#define AM_BSP_IOM3_CS_CHNL             0
+
+//*****************************************************************************
+//
+//  IOM3_MISO pin: I/O Master 3 SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM3_MISO           	43
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM3_MISO;
+
+//*****************************************************************************
+//
+//  IOM3_MOSI pin: I/O Master 3 SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM3_MOSI           	38
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM3_MOSI;
+
+//*****************************************************************************
+//
+//  IOM3_SCK pin: I/O Master 3 SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM3_SCK            	42
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM3_SCK;
+
+//*****************************************************************************
+//
+//  IOM3_SCL pin: I/O Master 3 I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM3_SCL            	42
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM3_SCL;
+
+//*****************************************************************************
+//
+//  IOM3_SDA pin: I/O Master 3 I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM3_SDA            	43
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM3_SDA;
+
+//*****************************************************************************
+//
+//  IOM4_CS pin: I/O Master 4 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM4_CS             	13
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM4_CS;
+#define AM_BSP_IOM4_CS_CHNL             1
+
+//*****************************************************************************
+//
+//  IOM4_MISO pin: I/O Master 4 SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM4_MISO           	40
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM4_MISO;
+
+//*****************************************************************************
+//
+//  IOM4_MOSI pin: I/O Master 4 SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM4_MOSI           	44
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM4_MOSI;
+
+//*****************************************************************************
+//
+//  IOM4_SCK pin: I/O Master 4 SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM4_SCK            	39
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM4_SCK;
+
+//*****************************************************************************
+//
+//  IOM4_SCL pin: I/O Master 4 I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM4_SCL            	39
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM4_SCL;
+
+//*****************************************************************************
+//
+//  IOM4_SDA pin: I/O Master 4 I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM4_SDA            	40
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM4_SDA;
+
+//*****************************************************************************
+//
+//  IOM5_CS pin: I/O Master 5 chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM5_CS             	16
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM5_CS;
+#define AM_BSP_IOM5_CS_CHNL             0
+
+//*****************************************************************************
+//
+//  IOM5_MISO pin: I/O Master 5 SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM5_MISO           	49
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM5_MISO;
+
+//*****************************************************************************
+//
+//  IOM5_MOSI pin: I/O Master 5 SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM5_MOSI           	47
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM5_MOSI;
+
+//*****************************************************************************
+//
+//  IOM5_SCK pin: I/O Master 5 SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM5_SCK            	48
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM5_SCK;
+
+//*****************************************************************************
+//
+//  IOM5_SCL pin: I/O Master 5 I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM5_SCL            	48
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM5_SCL;
+
+//*****************************************************************************
+//
+//  IOM5_SDA pin: I/O Master 5 I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOM5_SDA            	49
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOM5_SDA;
+
+//*****************************************************************************
+//
+//  MSPI_CE0 pin: MSPI chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_CE0            	19
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_CE0;
+#define AM_BSP_MSPI_CE0_CHNL            0
+
+//*****************************************************************************
+//
+//  MSPI_CE1 pin: MSPI chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_CE1            	41
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_CE1;
+#define AM_BSP_MSPI_CE1_CHNL            1
+
+//*****************************************************************************
+//
+//  MSPI_D0 pin: MSPI data 0.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D0             	22
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D0;
+
+//*****************************************************************************
+//
+//  MSPI_D1 pin: MSPI data 1.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D1             	26
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D1;
+
+//*****************************************************************************
+//
+//  MSPI_D2 pin: MSPI data 2.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D2             	4
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D2;
+
+//*****************************************************************************
+//
+//  MSPI_D3 pin: MSPI data 3.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D3             	23
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D3;
+
+//*****************************************************************************
+//
+//  MSPI_D4 pin: MSPI data 4.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D4             	0
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D4;
+
+//*****************************************************************************
+//
+//  MSPI_D5 pin: MSPI data 5.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D5             	1
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D5;
+
+//*****************************************************************************
+//
+//  MSPI_D6 pin: MSPI data 6.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D6             	2
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D6;
+
+//*****************************************************************************
+//
+//  MSPI_D7 pin: MSPI data 7.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_D7             	3
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_D7;
+
+//*****************************************************************************
+//
+//  MSPI_SCK pin: MSPI clock.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_MSPI_SCK            	24
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_MSPI_SCK;
+
+//*****************************************************************************
+//
+//  IOS_CE pin: I/O Slave chip select.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOS_CE              	3
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOS_CE;
+#define AM_BSP_IOS_CE_CHNL              0
+
+//*****************************************************************************
+//
+//  IOS_MISO pin: I/O Slave SPI MISO signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOS_MISO            	2
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOS_MISO;
+
+//*****************************************************************************
+//
+//  IOS_MOSI pin: I/O Slave SPI MOSI signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOS_MOSI            	1
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOS_MOSI;
+
+//*****************************************************************************
+//
+//  IOS_SCK pin: I/O Slave SPI SCK signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOS_SCK             	0
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOS_SCK;
+
+//*****************************************************************************
+//
+//  IOS_SCL pin: I/O Slave I2C clock signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOS_SCL             	0
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOS_SCL;
+
+//*****************************************************************************
+//
+//  IOS_SDA pin: I/O Slave I2C data signal.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_IOS_SDA             	1
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_IOS_SDA;
+
+//*****************************************************************************
+//
+//  ITM_SWO pin: ITM Serial Wire Output.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_ITM_SWO             	33
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_ITM_SWO;
+
+//*****************************************************************************
+//
+//  SWDCK pin: Cortex Serial Wire DCK.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_SWDCK               	20
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_SWDCK;
+
+//*****************************************************************************
+//
+//  SWDIO pin: Cortex Serial Wire DIO.
+//
+//*****************************************************************************
+#define AM_BSP_GPIO_SWDIO               	21
+extern const am_hal_gpio_pincfg_t       g_AM_BSP_GPIO_SWDIO;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AM_BSP_PINS_H
+
+//*****************************************************************************
+//
+// End Doxygen group.
+//! @}
+//
+//*****************************************************************************

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -7463,6 +7463,9 @@
         "inherits": ["AMA3B1KK"],
         "components_add": ["lis2dh12", "hm01b0"]
     },
+	 "LoRa_THING_PLUS_expLoRaBLE": {
+        "inherits": ["AMA3B1KK"]
+    },
     "__build_tools_metadata__": {
         "version": "1",
         "public": false


### PR DESCRIPTION
Added target for LoRa thing plus in mbed to support Arduino core.
Removed changes which were likely due to not updating fork prior to PR.
Submitting along with PR https://github.com/sparkfun/Arduino_Apollo3/pull/305, adding the LoRa thing plus variant to Arduino core